### PR TITLE
Added logging to highlight the bug

### DIFF
--- a/src/main/java/world/bentobox/biomes/BiomesAddonManager.java
+++ b/src/main/java/world/bentobox/biomes/BiomesAddonManager.java
@@ -36,662 +36,672 @@ import world.bentobox.biomes.utils.Utils;
  */
 public class BiomesAddonManager
 {
-	/**
-	 * This is default constructor for Addon Manager.
-	 * @param addon Inits addon manager.
-	 */
-	protected BiomesAddonManager(BiomesAddon addon)
-	{
-		this.addon = addon;
-
-		this.biomesDatabase = new Database<>(addon, BiomesObject.class);
-		this.biomesCacheData = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-
-		this.biomesFile = new File(this.addon.getDataFolder(), "biomes.yml");
-
-		if (!this.biomesFile.exists())
-		{
-			this.addon.saveResource("biomes.yml", false);
-		}
-
-		this.biomePendingChunkUpdateDatabase = new Database<>(addon, BiomeChunkUpdateObject.class);
-		this.biomePendingChunkUpdateMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-
-		this.load();
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Loading
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * Creates biomes cache.
-	 */
-	private void load()
-	{
-		this.biomesCacheData.clear();
-		this.biomePendingChunkUpdateMap.clear();
-
-		this.addon.getLogger().info("Loading biomes...");
-
-		this.biomesDatabase.loadObjects().forEach(this::loadBiomes);
-		this.biomePendingChunkUpdateDatabase.loadObjects().forEach(this::addChunkUpdateObject);
-	}
-
-
-	/**
-	 * This class reload
-	 */
-	public void reload()
-	{
-		this.addon.getLogger().info("Reloading biomes...");
-
-		this.biomesDatabase = new Database<>(this.addon, BiomesObject.class);
-		this.biomesDatabase.loadObjects().forEach(this::loadBiomes);
-
-		this.biomePendingChunkUpdateDatabase = new Database<>(this.addon, BiomeChunkUpdateObject.class);
-		this.biomePendingChunkUpdateDatabase.loadObjects().forEach(this::addChunkUpdateObject);
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Storing
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * This method allows to store single biome object.
-	 * @param biome Biome that must be saved in database.
-	 */
-	public void saveBiome(BiomesObject biome)
-	{
-		this.biomesDatabase.saveObject(biome);
-	}
-
-
-	/**
-	 * Save biomes from cache into database
-	 */
-	public void save()
-	{
-		this.biomesCacheData.values().forEach(this.biomesDatabase::saveObject);
-
-		// Clear Database.
-		List<BiomeChunkUpdateObject> objectList =
-			this.biomePendingChunkUpdateDatabase.loadObjects();
-		objectList.forEach(object -> this.biomePendingChunkUpdateDatabase.
-			deleteID(object.getUniqueId()));
-
-		// Save cache into database.
-		if (!this.biomePendingChunkUpdateMap.isEmpty())
-		{
-			this.biomePendingChunkUpdateMap.values().forEach(
-				this.biomePendingChunkUpdateDatabase::saveObject);
-		}
-	}
-
-	/**
-	 * Loads biomes in cache silently. Used when loading.
-	 * @param biome that must be stored.
-	 * @return true if successful
-	 */
-	private boolean loadBiomes(BiomesObject biome)
-	{
-		return this.loadBiomes(biome, true, null, true);
-	}
-
-
-	/**
-	 * Load biomes in the cache.
-	 * @param biome - biome that must be stored.
-	 * @param overwrite - true if previous biomes should be overwritten
-	 * @param user - user making the request
-	 * @param silent - if true, no messages are sent to user
-	 * @return - true if imported
-	 */
-	public boolean loadBiomes(BiomesObject biome, boolean overwrite, User user, boolean silent)
-	{
-		// If biome is null, the skip this biome!
-		if (biome.getBiome() == null)
-		{
-			if (!silent)
-			{
-				user.sendMessage("biomes.messages.skipping",
-					"[biome]",
-					biome.toString());
-			}
-
-			return false;
-		}
-
-		// Contains in array list is not fast.. but list is not so large, so it is ok there.
-
-		if (this.biomesCacheData.containsKey(biome.getUniqueId()))
-		{
-			if (!overwrite)
-			{
-				if (!silent)
-				{
-					user.sendMessage("biomes.messages.skipping",
-						"[biome]",
-						biome.getFriendlyName());
-				}
-
-				return false;
-			}
-			else
-			{
-				if (!silent)
-				{
-					user.sendMessage("biomes.messages.overwriting",
-						"[biome]",
-						biome.getFriendlyName());
-				}
-
-				this.biomesCacheData.replace(biome.getUniqueId(), biome);
-				return true;
-			}
-		}
-
-		if (!silent)
-		{
-			user.sendMessage("biomes.messages.imported",
-				"[biome]",
-				biome.getFriendlyName());
-		}
-
-		this.biomesCacheData.put(biome.getUniqueId(), biome);
-		return true;
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Importing
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * This method imports biomes
-	 *
-	 * @param user - user
-	 * @param world - world to import into
-	 * @param overwrite - true if previous ones should be overwritten
-	 * @return true if successful
-	 */
-	public boolean importBiomes(User user, World world, boolean overwrite)
-	{
-		world = Util.getWorld(world);
-
-		if (!this.biomesFile.exists())
-		{
-			user.sendMessage("biomes.errors.no-file");
-			return false;
-		}
-
-		YamlConfiguration config = new YamlConfiguration();
-
-		try
-		{
-			config.load(this.biomesFile);
-		}
-		catch (IOException | InvalidConfigurationException e)
-		{
-			user.sendMessage("biomes.errors.no-load",
-				"[message]",
-				e.getMessage());
-			return false;
-		}
-
-		this.readBiomes(config, user, world, overwrite);
-
-		// Update biome order.
-		this.addon.getAddonManager().save();
-		return true;
-	}
-
-
-	/**
-	 * This method creates biomes object from config file.
-	 * @param config YamlConfiguration that contains all biomes.
-	 * @param user User who calls reading.
-	 * @param world World in which biomes must be imported
-	 * @param overwrite Boolean that indicate if biomes should be overwritted.
-	 */
-	private void readBiomes(YamlConfiguration config, User user, World world, boolean overwrite)
-	{
-		int size = 0;
-
-		ConfigurationSection reader = config.getConfigurationSection("biomes.biomesList");
-
-		Map<String, Biome> biomeNameMap = BiomesAddonManager.getBiomeNameMap();
-
-		for (String biome : reader.getKeys(false))
-		{
-			if (biomeNameMap.containsKey(biome.toUpperCase()))
-			{
-				BiomesObject newBiomeObject = new BiomesObject(Biome.valueOf(biome.toUpperCase()), world);
-				newBiomeObject.setDeployed(true);
-
-				ConfigurationSection details = reader.getConfigurationSection(biome);
-
-				newBiomeObject.setFriendlyName(details.getString("friendlyName", biome));
-
-				newBiomeObject.setDescription(
-					GuiUtils.stringSplit(details.getString("description", ""),
-						this.addon.getSettings().getLoreLineLength()));
-				newBiomeObject.setIcon(ItemParser.parse(details.getString("icon") + ":1"));
-
-				newBiomeObject.setRequiredLevel(details.getInt("islandLevel", 0));
-				newBiomeObject.setRequiredCost(details.getInt("cost", 0));
-
-				List<String> permissions = details.getStringList("permission");
-
-				if (permissions == null || permissions.isEmpty())
-				{
-					newBiomeObject.setRequiredPermissions(Collections.emptySet());
-				}
-				else
-				{
-					newBiomeObject.setRequiredPermissions(new HashSet<>(permissions));
-				}
-
-				if (this.addon.getAddonManager().loadBiomes(
-					newBiomeObject, overwrite, user, false))
-				{
-					size++;
-				}
-			}
-			else
-			{
-				user.sendMessage("biomes.errors.load-biome",
-					"[biome]",
-					biome);
-			}
-		}
-
-		user.sendMessage("biomes.messages.import-count",
-			"[number]",
-			String.valueOf(size));
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Migrate
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * This method migrated all biomes addon data from worldName to addonID format.
-	 */
-	public void migrateDatabase(User user, World world)
-	{
-		world = Util.getWorld(world);
-
-		if (user.isPlayer())
-		{
-			user.sendMessage("biomes.messages.admin.migrate-start");
-		}
-		else
-		{
-			this.addon.log("Starting migration to new data format.");
-		}
-
-		boolean biomes = this.migrateBiomes(world);
-
-		if (biomes)
-		{
-			if (user.isPlayer())
-			{
-				user.sendMessage("biomes.messages.admin.migrate-end");
-			}
-			else
-			{
-				this.addon.log("Migration to new data format completed.");
-			}
-		}
-		else
-		{
-			if (user.isPlayer())
-			{
-				user.sendMessage("biomes.messages.admin.migrate-not");
-			}
-			else
-			{
-				this.addon.log("All data is valid. Migration is not necessary.");
-			}
-		}
-	}
-
-
-	/**
-	 * This method migrates biomes object to new id format.
-	 * @param world World which biomes must be updated.
-	 * @return {@code true} if any biome is updated,
-	 * 			{@code false} otherwise.
-	 */
-	private boolean migrateBiomes(World world)
-	{
-		String addonName = Utils.getGameMode(world);
-
-		if (addonName == null || addonName.equalsIgnoreCase(world.getName()))
-		{
-			return false;
-		}
-
-		boolean updated = false;
-		List<BiomesObject> objectList = this.biomesDatabase.loadObjects();
-
-		for (BiomesObject biomesObject : objectList)
-		{
-			if (biomesObject.getUniqueId().regionMatches(true, 0, world.getName() + "-", 0, world.getName().length() + 1))
-			{
-				this.biomesDatabase.deleteID(biomesObject.getUniqueId());
-				this.biomesCacheData.remove(biomesObject.getUniqueId());
-
-				biomesObject.setUniqueId(
-					addonName + "_" + biomesObject.getUniqueId().substring(world.getName().length() + 1));
-
-				// Update world, as in some situations it was not set.
-				biomesObject.setWorld(Util.getWorld(world).getName());
-
-				this.biomesDatabase.saveObject(biomesObject);
-				this.biomesCacheData.put(biomesObject.getUniqueId(), biomesObject);
-
-				updated = true;
-			}
-		}
-
-		return updated;
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Creating
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * This method creates and returns new biome with given uniqueID.
-	 * @param uniqueID - new ID for challenge.
-	 * @param worldName - world name where biome operates.
-	 * @return biome that is currently created.
-	 */
-	public BiomesObject createBiome(String uniqueID, String worldName)
-	{
-		if (!this.containsBiome(uniqueID))
-		{
-			BiomesObject biome = new BiomesObject();
-			biome.setUniqueId(uniqueID);
-
-			// Sets default biome as VOID.
-			biome.setBiome(Biome.THE_VOID);
-			biome.setWorld(worldName);
-
-			this.saveBiome(biome);
-			this.loadBiomes(biome);
-
-			return biome;
-		}
-		else
-		{
-			return null;
-		}
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Getters / Setters
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * This method returns biomes that is visible for user by using default visibility mode.
-	 * @param world World in which biomes must be returned.
-	 * @param user User who will see biomes.
-	 * @return Visible biome list.
-	 */
-	public List<BiomesObject> getBiomes(World world, User user)
-	{
-		return this.getBiomes(world, user, this.addon.getSettings().getVisibilityMode());
-	}
-
-
-	/**
-	 * This method returns biomes that is visible for user in given world.
-	 * @param world World in which biomes must be returned.
-	 * @param user User who will see biomes.
-	 * @param visibilityMode active visibilityMode. Only ALL will return all biomes.
-	 * DEPLOYED will show biomes that has deployedFlag enabled.
-	 * ACCESSIBLE will show biomes that are deployed and user has permission that unlocks biome.
-	 * TOGGLEABLE will work as ACCESSIBLE.
-	 * @return Visible biome list.
-	 */
-	public List<BiomesObject> getBiomes(World world, User user, VisibilityMode visibilityMode)
-	{
-		List<BiomesObject> allBiomeList = this.getBiomes(world);
-
-		if (visibilityMode.equals(VisibilityMode.ALL))
-		{
-			return allBiomeList;
-		}
-
-		List<BiomesObject> returnBiomesList = new ArrayList<>(allBiomeList.size());
-
-		allBiomeList.forEach(biomesObject -> {
-			if (biomesObject.isDeployed() &&
-				(visibilityMode.equals(VisibilityMode.DEPLOYED) ||
-					biomesObject.getRequiredPermissions().isEmpty() ||
-					biomesObject.getRequiredPermissions().stream().allMatch(user::hasPermission)))
-			{
-				returnBiomesList.add(biomesObject);
-			}
-		});
-
-		return returnBiomesList;
-	}
-
-
-	/**
-	 * This method returns list with loaded biomes for given world.
-	 * @param world World where biome operates.
-	 * @return list with loaded biomes.
-	 */
-	public List<BiomesObject> getBiomes(World world)
-	{
-		world = Util.getWorld(world);
-
-		return world == null ? Collections.emptyList() : this.getBiomes(world.getName());
-	}
-
-
-	/**
-	 * This method returns list with loaded biomes for given world.
-	 * @param worldName Name of world where biome operates.
-	 * @return list with loaded biomes.
-	 */
-	public List<BiomesObject> getBiomes(String worldName)
-	{
-		return this.biomesCacheData.values().stream().
-			sorted(BiomesObject::compareTo).
-			filter(biome -> biome.getWorld().equalsIgnoreCase(worldName)).
-			collect(Collectors.toList());
-	}
-
-
-	/**
-	 * This method returns biome object that hides behind biome name or null, if biome
-	 * with name does not exist.
-	 * @param biomeUniqueID Biome's name.
-	 * @return BiomesObject that is represented by biome string.
-	 */
-	public BiomesObject getBiomeFromString(String biomeUniqueID)
-	{
-		return this.biomesCacheData.getOrDefault(biomeUniqueID, null);
-	}
-
-
-	/**
-	 * Check if a biome exists - case insensitive
-	 *
-	 * @param name - name of biome
-	 * @return true if it exists, otherwise false
-	 */
-	public boolean containsBiome(String name)
-	{
-		if (this.biomesCacheData.containsKey(name))
-		{
-			return true;
-		}
-		else
-		{
-			// check database.
-			if (this.biomesDatabase.objectExists(name))
-			{
-				BiomesObject biome = this.biomesDatabase.loadObject(name);
-				this.biomesCacheData.put(name, biome);
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-
-	/**
-	 * Given method removes biome from database and cache.
-	 * @param biome Biome that must be removed.
-	 */
-	public void removeBiome(BiomesObject biome)
-	{
-		if (this.biomesCacheData.containsKey(biome.getUniqueId()))
-		{
-			this.biomesCacheData.remove(biome.getUniqueId());
-			this.biomesDatabase.deleteObject(biome);
-		}
-	}
-
-
-	/**
-	 * This method returns map that contains biomes name as key and biome as value.
-	 * @return Map that contains relation from biome name to biome.
-	 */
-	public static Map<String, Biome> getBiomeNameMap()
-	{
-		Biome[] biomes = Biome.values();
-
-		Map<String, Biome> returnMap = new HashMap<>(biomes.length);
-
-		for (Biome biome : biomes)
-		{
-			returnMap.put(biome.name(), biome);
-		}
-
-		return returnMap;
-	}
-
-
-	/**
-	 * This method returns if in given world biomes are setup.
-	 * @param world World that must be checked.
-	 * @return True if in given world exist biomes.
-	 */
-	public boolean hasAnyBiome(World world)
-	{
-		String worldName = Util.getWorld(world) == null ? "" : Util.getWorld(world).getName();
-
-		return !worldName.isEmpty() &&
-			this.biomesCacheData.values().stream().anyMatch(biome -> biome.getWorld().equalsIgnoreCase(worldName));
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Later Biome Updater
-// ---------------------------------------------------------------------
-
-
-	/**
-	 * This method finds and returns BiomeChunkUpdaterObject in given world with given
-	 * chunk X and Z coordinates.
-	 * @param world World where process will happen.
-	 * @param x Chunk X coordinate.
-	 * @param z Chunk Z coordinate.
-	 * @return BiomeChunkUpdateObject where update is pending or null.
-	 */
-	public BiomeChunkUpdateObject getPendingChunkUpdateObject(World world, int x, int z)
-	{
-		return this.biomePendingChunkUpdateMap.get(Utils.getGameMode(world) + "_" + x + "-" + z);
-	}
-
-
-	/**
-	 * This method returns collection with all objects that contains information about
-	 * chunks where biome update is still not completed.
-	 * @return Collection of BiomeCHunkUpdateObjects.
-	 */
-	public Collection<BiomeChunkUpdateObject> getBiomeUpdaterCollection()
-	{
-		return this.biomePendingChunkUpdateMap.values();
-	}
-
-
-	/**
-	 * This method adds BiomeChunkUpdateObject to cache.
-	 * @param updateObject Object that must be added to cache.
-	 */
-	public void addChunkUpdateObject(BiomeChunkUpdateObject updateObject)
-	{
-		this.biomePendingChunkUpdateMap.put(updateObject.getUniqueId(), updateObject);
-	}
-
-
-	/**
-	 * This method removes given element form cache and database.
-	 * @param element Element that should be removed.
-	 */
-	public void removeUpdateObject(BiomeChunkUpdateObject element)
-	{
-		if (this.biomePendingChunkUpdateMap.containsKey(element.getUniqueId()))
-		{
-			this.biomePendingChunkUpdateMap.remove(element.getUniqueId());
-			this.biomePendingChunkUpdateDatabase.deleteObject(element);
-		}
-	}
-
-
-// ---------------------------------------------------------------------
-// Section: Variables
-// ---------------------------------------------------------------------
-
-	/**
-	 * Variable current addon.
-	 */
-	private BiomesAddon addon;
-
-	/**
-	 * Variable stores map that links String to loaded biomes object.
-	 */
-	private Map<String, BiomesObject> biomesCacheData;
-
-	/**
-	 * Variable stores database of biomes objects.
-	 */
-	private Database<BiomesObject> biomesDatabase;
-
-	/**
-	 * Variable stores biomes.yml location
-	 */
-	private File biomesFile;
-
-	/**
-	 * Variable stores BiomeChunkUpdateObject objects that contains information about
-	 * chunk that is not updated yet.
-	 */
-	private Map<String, BiomeChunkUpdateObject> biomePendingChunkUpdateMap;
-
-	/**
-	 * Variable stores database of BiomeChunkUpdateObject.
-	 */
-	private Database<BiomeChunkUpdateObject> biomePendingChunkUpdateDatabase;
+    /**
+     * This is default constructor for Addon Manager.
+     * @param addon Inits addon manager.
+     */
+    protected BiomesAddonManager(BiomesAddon addon)
+    {
+        this.addon = addon;
+
+        this.biomesDatabase = new Database<>(addon, BiomesObject.class);
+        this.biomesCacheData = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        this.biomesFile = new File(this.addon.getDataFolder(), "biomes.yml");
+
+        if (!this.biomesFile.exists())
+        {
+            this.addon.saveResource("biomes.yml", false);
+        }
+
+        this.biomePendingChunkUpdateDatabase = new Database<>(addon, BiomeChunkUpdateObject.class);
+        this.biomePendingChunkUpdateMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        this.load();
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Loading
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * Creates biomes cache.
+     */
+    private void load()
+    {
+        this.biomesCacheData.clear();
+        this.biomePendingChunkUpdateMap.clear();
+
+        this.addon.getLogger().info("Loading biomes...");
+
+        this.biomesDatabase.loadObjects().forEach(this::loadBiomes);
+        this.biomePendingChunkUpdateDatabase.loadObjects().forEach(this::addChunkUpdateObject);
+    }
+
+
+    /**
+     * This class reload
+     */
+    public void reload()
+    {
+        this.addon.getLogger().info("Reloading biomes...");
+
+        this.biomesDatabase = new Database<>(this.addon, BiomesObject.class);
+        this.biomesDatabase.loadObjects().forEach(this::loadBiomes);
+
+        this.biomePendingChunkUpdateDatabase = new Database<>(this.addon, BiomeChunkUpdateObject.class);
+        this.biomePendingChunkUpdateDatabase.loadObjects().forEach(this::addChunkUpdateObject);
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Storing
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * This method allows to store single biome object.
+     * @param biome Biome that must be saved in database.
+     */
+    public void saveBiome(BiomesObject biome)
+    {
+        this.biomesDatabase.saveObject(biome);
+    }
+
+
+    /**
+     * Save biomes from cache into database
+     */
+    public void save()
+    {
+        this.biomesCacheData.values().forEach(this.biomesDatabase::saveObject);
+
+        // Clear Database.
+        List<BiomeChunkUpdateObject> objectList =
+                this.biomePendingChunkUpdateDatabase.loadObjects();
+        objectList.forEach(object -> this.biomePendingChunkUpdateDatabase.
+                deleteID(object.getUniqueId()));
+
+        // Save cache into database.
+        if (!this.biomePendingChunkUpdateMap.isEmpty())
+        {
+            addon.getPlugin().logDebug("Saving cache");
+            this.biomePendingChunkUpdateMap.values().forEach(
+                    this.biomePendingChunkUpdateDatabase::saveObject);
+        }
+    }
+
+    /**
+     * Loads biomes in cache silently. Used when loading.
+     * @param biome that must be stored.
+     * @return true if successful
+     */
+    private boolean loadBiomes(BiomesObject biome)
+    {
+        return this.loadBiomes(biome, true, null, true);
+    }
+
+
+    /**
+     * Load biomes in the cache.
+     * @param biome - biome that must be stored.
+     * @param overwrite - true if previous biomes should be overwritten
+     * @param user - user making the request
+     * @param silent - if true, no messages are sent to user
+     * @return - true if imported
+     */
+    public boolean loadBiomes(BiomesObject biome, boolean overwrite, User user, boolean silent)
+    {
+        // If biome is null, the skip this biome!
+        if (biome.getBiome() == null)
+        {
+            if (!silent)
+            {
+                user.sendMessage("biomes.messages.skipping",
+                        "[biome]",
+                        biome.toString());
+            }
+
+            return false;
+        }
+
+        // Contains in array list is not fast.. but list is not so large, so it is ok there.
+
+        if (this.biomesCacheData.containsKey(biome.getUniqueId()))
+        {
+            if (!overwrite)
+            {
+                if (!silent)
+                {
+                    user.sendMessage("biomes.messages.skipping",
+                            "[biome]",
+                            biome.getFriendlyName());
+                }
+
+                return false;
+            }
+            else
+            {
+                if (!silent)
+                {
+                    user.sendMessage("biomes.messages.overwriting",
+                            "[biome]",
+                            biome.getFriendlyName());
+                }
+
+                this.biomesCacheData.replace(biome.getUniqueId(), biome);
+                return true;
+            }
+        }
+
+        if (!silent)
+        {
+            user.sendMessage("biomes.messages.imported",
+                    "[biome]",
+                    biome.getFriendlyName());
+        }
+
+        this.biomesCacheData.put(biome.getUniqueId(), biome);
+        return true;
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Importing
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * This method imports biomes
+     *
+     * @param user - user
+     * @param world - world to import into
+     * @param overwrite - true if previous ones should be overwritten
+     * @return true if successful
+     */
+    public boolean importBiomes(User user, World world, boolean overwrite)
+    {
+        world = Util.getWorld(world);
+
+        if (!this.biomesFile.exists())
+        {
+            user.sendMessage("biomes.errors.no-file");
+            return false;
+        }
+
+        YamlConfiguration config = new YamlConfiguration();
+
+        try
+        {
+            config.load(this.biomesFile);
+        }
+        catch (IOException | InvalidConfigurationException e)
+        {
+            user.sendMessage("biomes.errors.no-load",
+                    "[message]",
+                    e.getMessage());
+            return false;
+        }
+
+        this.readBiomes(config, user, world, overwrite);
+
+        // Update biome order.
+        this.addon.getAddonManager().save();
+        return true;
+    }
+
+
+    /**
+     * This method creates biomes object from config file.
+     * @param config YamlConfiguration that contains all biomes.
+     * @param user User who calls reading.
+     * @param world World in which biomes must be imported
+     * @param overwrite Boolean that indicate if biomes should be overwritted.
+     */
+    private void readBiomes(YamlConfiguration config, User user, World world, boolean overwrite)
+    {
+        int size = 0;
+
+        ConfigurationSection reader = config.getConfigurationSection("biomes.biomesList");
+
+        Map<String, Biome> biomeNameMap = BiomesAddonManager.getBiomeNameMap();
+
+        for (String biome : reader.getKeys(false))
+        {
+            if (biomeNameMap.containsKey(biome.toUpperCase()))
+            {
+                BiomesObject newBiomeObject = new BiomesObject(Biome.valueOf(biome.toUpperCase()), world);
+                newBiomeObject.setDeployed(true);
+
+                ConfigurationSection details = reader.getConfigurationSection(biome);
+
+                newBiomeObject.setFriendlyName(details.getString("friendlyName", biome));
+
+                newBiomeObject.setDescription(
+                        GuiUtils.stringSplit(details.getString("description", ""),
+                                this.addon.getSettings().getLoreLineLength()));
+                newBiomeObject.setIcon(ItemParser.parse(details.getString("icon") + ":1"));
+
+                newBiomeObject.setRequiredLevel(details.getInt("islandLevel", 0));
+                newBiomeObject.setRequiredCost(details.getInt("cost", 0));
+
+                List<String> permissions = details.getStringList("permission");
+
+                if (permissions == null || permissions.isEmpty())
+                {
+                    newBiomeObject.setRequiredPermissions(Collections.emptySet());
+                }
+                else
+                {
+                    newBiomeObject.setRequiredPermissions(new HashSet<>(permissions));
+                }
+
+                if (this.addon.getAddonManager().loadBiomes(
+                        newBiomeObject, overwrite, user, false))
+                {
+                    size++;
+                }
+            }
+            else
+            {
+                user.sendMessage("biomes.errors.load-biome",
+                        "[biome]",
+                        biome);
+            }
+        }
+
+        user.sendMessage("biomes.messages.import-count",
+                "[number]",
+                String.valueOf(size));
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Migrate
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * This method migrated all biomes addon data from worldName to addonID format.
+     */
+    public void migrateDatabase(User user, World world)
+    {
+        world = Util.getWorld(world);
+
+        if (user.isPlayer())
+        {
+            user.sendMessage("biomes.messages.admin.migrate-start");
+        }
+        else
+        {
+            this.addon.log("Starting migration to new data format.");
+        }
+
+        boolean biomes = this.migrateBiomes(world);
+
+        if (biomes)
+        {
+            if (user.isPlayer())
+            {
+                user.sendMessage("biomes.messages.admin.migrate-end");
+            }
+            else
+            {
+                this.addon.log("Migration to new data format completed.");
+            }
+        }
+        else
+        {
+            if (user.isPlayer())
+            {
+                user.sendMessage("biomes.messages.admin.migrate-not");
+            }
+            else
+            {
+                this.addon.log("All data is valid. Migration is not necessary.");
+            }
+        }
+    }
+
+
+    /**
+     * This method migrates biomes object to new id format.
+     * @param world World which biomes must be updated.
+     * @return {@code true} if any biome is updated,
+     * 			{@code false} otherwise.
+     */
+    private boolean migrateBiomes(World world)
+    {
+        String addonName = Utils.getGameMode(world);
+
+        if (addonName == null || addonName.equalsIgnoreCase(world.getName()))
+        {
+            return false;
+        }
+
+        boolean updated = false;
+        List<BiomesObject> objectList = this.biomesDatabase.loadObjects();
+
+        for (BiomesObject biomesObject : objectList)
+        {
+            if (biomesObject.getUniqueId().regionMatches(true, 0, world.getName() + "-", 0, world.getName().length() + 1))
+            {
+                this.biomesDatabase.deleteID(biomesObject.getUniqueId());
+                this.biomesCacheData.remove(biomesObject.getUniqueId());
+
+                biomesObject.setUniqueId(
+                        addonName + "_" + biomesObject.getUniqueId().substring(world.getName().length() + 1));
+
+                // Update world, as in some situations it was not set.
+                biomesObject.setWorld(Util.getWorld(world).getName());
+
+                this.biomesDatabase.saveObject(biomesObject);
+                this.biomesCacheData.put(biomesObject.getUniqueId(), biomesObject);
+
+                updated = true;
+            }
+        }
+
+        return updated;
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Creating
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * This method creates and returns new biome with given uniqueID.
+     * @param uniqueID - new ID for challenge.
+     * @param worldName - world name where biome operates.
+     * @return biome that is currently created.
+     */
+    public BiomesObject createBiome(String uniqueID, String worldName)
+    {
+        if (!this.containsBiome(uniqueID))
+        {
+            BiomesObject biome = new BiomesObject();
+            biome.setUniqueId(uniqueID);
+
+            // Sets default biome as VOID.
+            biome.setBiome(Biome.THE_VOID);
+            biome.setWorld(worldName);
+
+            this.saveBiome(biome);
+            this.loadBiomes(biome);
+
+            return biome;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Getters / Setters
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * This method returns biomes that is visible for user by using default visibility mode.
+     * @param world World in which biomes must be returned.
+     * @param user User who will see biomes.
+     * @return Visible biome list.
+     */
+    public List<BiomesObject> getBiomes(World world, User user)
+    {
+        return this.getBiomes(world, user, this.addon.getSettings().getVisibilityMode());
+    }
+
+
+    /**
+     * This method returns biomes that is visible for user in given world.
+     * @param world World in which biomes must be returned.
+     * @param user User who will see biomes.
+     * @param visibilityMode active visibilityMode. Only ALL will return all biomes.
+     * DEPLOYED will show biomes that has deployedFlag enabled.
+     * ACCESSIBLE will show biomes that are deployed and user has permission that unlocks biome.
+     * TOGGLEABLE will work as ACCESSIBLE.
+     * @return Visible biome list.
+     */
+    public List<BiomesObject> getBiomes(World world, User user, VisibilityMode visibilityMode)
+    {
+        List<BiomesObject> allBiomeList = this.getBiomes(world);
+
+        if (visibilityMode.equals(VisibilityMode.ALL))
+        {
+            return allBiomeList;
+        }
+
+        List<BiomesObject> returnBiomesList = new ArrayList<>(allBiomeList.size());
+
+        allBiomeList.forEach(biomesObject -> {
+            if (biomesObject.isDeployed() &&
+                    (visibilityMode.equals(VisibilityMode.DEPLOYED) ||
+                            biomesObject.getRequiredPermissions().isEmpty() ||
+                            biomesObject.getRequiredPermissions().stream().allMatch(user::hasPermission)))
+            {
+                returnBiomesList.add(biomesObject);
+            }
+        });
+
+        return returnBiomesList;
+    }
+
+
+    /**
+     * This method returns list with loaded biomes for given world.
+     * @param world World where biome operates.
+     * @return list with loaded biomes.
+     */
+    public List<BiomesObject> getBiomes(World world)
+    {
+        world = Util.getWorld(world);
+
+        return world == null ? Collections.emptyList() : this.getBiomes(world.getName());
+    }
+
+
+    /**
+     * This method returns list with loaded biomes for given world.
+     * @param worldName Name of world where biome operates.
+     * @return list with loaded biomes.
+     */
+    public List<BiomesObject> getBiomes(String worldName)
+    {
+        return this.biomesCacheData.values().stream().
+                sorted(BiomesObject::compareTo).
+                filter(biome -> biome.getWorld().equalsIgnoreCase(worldName)).
+                collect(Collectors.toList());
+    }
+
+
+    /**
+     * This method returns biome object that hides behind biome name or null, if biome
+     * with name does not exist.
+     * @param biomeUniqueID Biome's name.
+     * @return BiomesObject that is represented by biome string.
+     */
+    public BiomesObject getBiomeFromString(String biomeUniqueID)
+    {
+        return this.biomesCacheData.getOrDefault(biomeUniqueID, null);
+    }
+
+
+    /**
+     * Check if a biome exists - case insensitive
+     *
+     * @param name - name of biome
+     * @return true if it exists, otherwise false
+     */
+    public boolean containsBiome(String name)
+    {
+        if (this.biomesCacheData.containsKey(name))
+        {
+            return true;
+        }
+        else
+        {
+            // check database.
+            if (this.biomesDatabase.objectExists(name))
+            {
+                BiomesObject biome = this.biomesDatabase.loadObject(name);
+                this.biomesCacheData.put(name, biome);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Given method removes biome from database and cache.
+     * @param biome Biome that must be removed.
+     */
+    public void removeBiome(BiomesObject biome)
+    {
+        if (this.biomesCacheData.containsKey(biome.getUniqueId()))
+        {
+            this.biomesCacheData.remove(biome.getUniqueId());
+            if (this.biomesDatabase.objectExists(biome.getUniqueId()))
+            {
+                this.biomesDatabase.deleteObject(biome);
+            } else {
+                addon.getPlugin().logDebug("No record of biomesDatabase object");
+            }
+        }
+    }
+
+
+    /**
+     * This method returns map that contains biomes name as key and biome as value.
+     * @return Map that contains relation from biome name to biome.
+     */
+    public static Map<String, Biome> getBiomeNameMap()
+    {
+        Biome[] biomes = Biome.values();
+
+        Map<String, Biome> returnMap = new HashMap<>(biomes.length);
+
+        for (Biome biome : biomes)
+        {
+            returnMap.put(biome.name(), biome);
+        }
+
+        return returnMap;
+    }
+
+
+    /**
+     * This method returns if in given world biomes are setup.
+     * @param world World that must be checked.
+     * @return True if in given world exist biomes.
+     */
+    public boolean hasAnyBiome(World world)
+    {
+        String worldName = Util.getWorld(world) == null ? "" : Util.getWorld(world).getName();
+
+        return !worldName.isEmpty() &&
+                this.biomesCacheData.values().stream().anyMatch(biome -> biome.getWorld().equalsIgnoreCase(worldName));
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Later Biome Updater
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * This method finds and returns BiomeChunkUpdaterObject in given world with given
+     * chunk X and Z coordinates.
+     * @param world World where process will happen.
+     * @param x Chunk X coordinate.
+     * @param z Chunk Z coordinate.
+     * @return BiomeChunkUpdateObject where update is pending or null.
+     */
+    public BiomeChunkUpdateObject getPendingChunkUpdateObject(World world, int x, int z)
+    {
+        return this.biomePendingChunkUpdateMap.get(Utils.getGameMode(world) + "_" + x + "-" + z);
+    }
+
+
+    /**
+     * This method returns collection with all objects that contains information about
+     * chunks where biome update is still not completed.
+     * @return Collection of BiomeCHunkUpdateObjects.
+     */
+    public Collection<BiomeChunkUpdateObject> getBiomeUpdaterCollection()
+    {
+        return this.biomePendingChunkUpdateMap.values();
+    }
+
+
+    /**
+     * This method adds BiomeChunkUpdateObject to cache.
+     * @param updateObject Object that must be added to cache.
+     */
+    public void addChunkUpdateObject(BiomeChunkUpdateObject updateObject)
+    {
+        this.biomePendingChunkUpdateMap.put(updateObject.getUniqueId(), updateObject);
+    }
+
+
+    /**
+     * This method removes given element form cache and database.
+     * @param element Element that should be removed.
+     */
+    public void removeUpdateObject(BiomeChunkUpdateObject element)
+    {
+        if (this.biomePendingChunkUpdateMap.containsKey(element.getUniqueId()))
+        {
+            this.biomePendingChunkUpdateMap.remove(element.getUniqueId());
+            if (this.biomePendingChunkUpdateDatabase.objectExists(element.getUniqueId())) {
+                this.biomePendingChunkUpdateDatabase.deleteObject(element);
+            } else {
+                addon.getPlugin().logDebug("No record of biomePendingChunkUpdateDatabase object");
+            }
+        }
+    }
+
+
+    // ---------------------------------------------------------------------
+    // Section: Variables
+    // ---------------------------------------------------------------------
+
+    /**
+     * Variable current addon.
+     */
+    private BiomesAddon addon;
+
+    /**
+     * Variable stores map that links String to loaded biomes object.
+     */
+    private Map<String, BiomesObject> biomesCacheData;
+
+    /**
+     * Variable stores database of biomes objects.
+     */
+    private Database<BiomesObject> biomesDatabase;
+
+    /**
+     * Variable stores biomes.yml location
+     */
+    private File biomesFile;
+
+    /**
+     * Variable stores BiomeChunkUpdateObject objects that contains information about
+     * chunk that is not updated yet.
+     */
+    private Map<String, BiomeChunkUpdateObject> biomePendingChunkUpdateMap;
+
+    /**
+     * Variable stores database of BiomeChunkUpdateObject.
+     */
+    private Database<BiomeChunkUpdateObject> biomePendingChunkUpdateDatabase;
 }


### PR DESCRIPTION
This is a bug on BentoBox, and also Biomes in a way. 
https://github.com/BentoBoxWorld/Biomes/issues/55

When running this build I see this when I change a biome:

```
[11:30:08 INFO]: tastybento issued server command: /is biomes
[11:30:11 INFO]: [BentoBox] [Biomes] tastybento change biome in loaded chunks to PLAINS from x=400:1199 z=-400:399 while standing on x=800 z=2
[11:30:11 INFO]: [BentoBox] [Biomes] Populated offline updater with 2059 chunks.
[11:30:11 INFO]: [BentoBox] DEBUG: No record of biomePendingChunkUpdateDatabase object
[11:30:11 INFO]: [BentoBox] DEBUG: No record of biomePendingChunkUpdateDatabase object
[11:30:12 INFO]: [BentoBox] DEBUG: No record of biomePendingChunkUpdateDatabase object
...
```

Chunks to update are never actually saved to the biomePendingChunkUpdateDatabase table in normal operation except on an onDisable() or during a migration situation. If the idea is to be able to resume after an orderly shutdown, this is probably okay. It won't recover from server crashes though. If this is okay, then nothing needs to be done and this PR can be closed because this BentoBox commit fixes the issue there:

https://github.com/BentoBoxWorld/BentoBox/commit/1304f8bace33784c2b1f96183cc8a0de57f202cc
