### PR TITLE
Changed Savanna to Savanna Plateau

### DIFF
--- a/src/main/resources/biomes.yml
+++ b/src/main/resources/biomes.yml
@@ -57,8 +57,8 @@ biomes:
       icon: 'snowball'
       islandLevel: 0
       cost: 100
-    savanna:
-      friendlyName: 'Savanna'
+    savanna_plateau:
+      friendlyName: 'Savanna Plateau'
       description: 'Where is my horse?'
       icon: 'grass'
       islandLevel: 0


### PR DESCRIPTION
Adds llama spawns to default skyblock biomes (They don't spawn in savanna)