### PR TITLE
Fix for #132

### DIFF
--- a/src/main/java/world/bentobox/biomes/commands/admin/AdminCommand.java
+++ b/src/main/java/world/bentobox/biomes/commands/admin/AdminCommand.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;

--- a/src/main/java/world/bentobox/biomes/commands/admin/AdminCommand.java
+++ b/src/main/java/world/bentobox/biomes/commands/admin/AdminCommand.java
@@ -6,13 +6,13 @@
 package world.bentobox.biomes.commands.admin;
 
 
-import org.bukkit.Bukkit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import world.bentobox.bentobox.BentoBox;
+import org.bukkit.Bukkit;
+
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;

--- a/src/main/java/world/bentobox/biomes/panels/user/AdvancedPanel.java
+++ b/src/main/java/world/bentobox/biomes/panels/user/AdvancedPanel.java
@@ -7,18 +7,18 @@
 package world.bentobox.biomes.panels.user;
 
 
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import world.bentobox.bentobox.BentoBox;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;

--- a/src/main/java/world/bentobox/biomes/panels/user/AdvancedPanel.java
+++ b/src/main/java/world/bentobox/biomes/panels/user/AdvancedPanel.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -487,6 +488,7 @@ public class AdvancedPanel extends CommonPanel
         else
         {
             // Target is specified. It means command must be called by the admin.
+            arguments.remove(0); // Remove "set"
             this.callCommand(false, "set", arguments);
         }
     }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -850,7 +850,7 @@ biomes:
     # Message that appears after clicking on download button in web library.
     start-downloading: "&e Start downloading library."
     # This message is sent to user when biome changing is started.
-    update-start: "&a Starting biome changing to [biome]&r&a in [number] chunks. &e Estimated time: [time] sec."
+    update-start: "&a Starting biome changing to [biome] &r&a in [number] chunks. &e Estimated time: [time] sec."
     # This message is sent to user when biome changing is finished.
     update-done: "&a Finished changing biome to [biome]&r&a."
     # This message is sent to user when his change is placed in queue.


### PR DESCRIPTION
Admin command creation in the panel was including "set" in the arguments, but was running the set command, so this was not needed.