### PR TITLE
Make biome unlock notifications gamemode-aware (#112)

### DIFF
--- a/src/main/java/world/bentobox/biomes/utils/Utils.java
+++ b/src/main/java/world/bentobox/biomes/utils/Utils.java
@@ -511,25 +511,32 @@ public class Utils
         World playerWorld = user.getWorld();
         String playerGameMode = playerWorld == null ? "" : getGameMode(playerWorld);
 
-        if (islandGameMode.isEmpty() || !islandGameMode.equals(playerGameMode))
+        if (!islandGameMode.isEmpty() && islandGameMode.equals(playerGameMode))
         {
-            return;
+            WorldSettings settings = addon.getPlugin().getIWM().getWorldSettings(island.getWorld());
+
+            StringBuilder commandBuilder = new StringBuilder();
+            commandBuilder.append("/");
+            commandBuilder.append(settings.getPlayerCommandAliases().split(" ")[0]);
+            commandBuilder.append(" ");
+            commandBuilder.append(addon.getSettings().getPlayerCommand().split(" ")[0]);
+
+            String key = available ? "click-text-to-set" : "click-text-to-purchase";
+            TextComponent component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + key,
+                    Constants.PARAMETER_BIOME, biome.getFriendlyName()));
+            component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandBuilder.toString()));
+
+            user.getPlayer().spigot().sendMessage(component);
         }
-
-        WorldSettings settings = addon.getPlugin().getIWM().getWorldSettings(island.getWorld());
-
-        StringBuilder commandBuilder = new StringBuilder();
-        commandBuilder.append("/");
-        commandBuilder.append(settings.getPlayerCommandAliases().split(" ")[0]);
-        commandBuilder.append(" ");
-        commandBuilder.append(addon.getSettings().getPlayerCommand().split(" ")[0]);
-
-        String key = available ? "click-text-to-set" : "click-text-to-purchase";
-        TextComponent component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + key,
-                Constants.PARAMETER_BIOME, biome.getFriendlyName()));
-        component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandBuilder.toString()));
-
-        user.getPlayer().spigot().sendMessage(component);
+        else
+        {
+            String gameModeName = BentoBox.getInstance().getIWM().getAddon(island.getWorld())
+                    .map(a -> a.getDescription().getName()).orElse("");
+            String key = available ? "click-text-to-set-other-world" : "click-text-to-purchase-other-world";
+            user.sendMessage(Constants.CONVERSATIONS + key,
+                    Constants.PARAMETER_BIOME, biome.getFriendlyName(),
+                    "[gamemode]", gameModeName);
+        }
     }
 
 

--- a/src/main/java/world/bentobox/biomes/utils/Utils.java
+++ b/src/main/java/world/bentobox/biomes/utils/Utils.java
@@ -502,11 +502,18 @@ public class Utils
             boolean available) {
         User user = User.getInstance(uuid);
 
-        WorldSettings settings = addon.getPlugin().getIWM().getWorldSettings(island.getWorld());
-
-        if (user.isOnline())
+        if (!user.isOnline())
         {
-            TextComponent component;
+            return;
+        }
+
+        String islandGameMode = getGameMode(island.getWorld());
+        World playerWorld = user.getWorld();
+        String playerGameMode = playerWorld == null ? "" : getGameMode(playerWorld);
+
+        if (!islandGameMode.isEmpty() && islandGameMode.equals(playerGameMode))
+        {
+            WorldSettings settings = addon.getPlugin().getIWM().getWorldSettings(island.getWorld());
 
             StringBuilder commandBuilder = new StringBuilder();
             commandBuilder.append("/");
@@ -514,18 +521,21 @@ public class Utils
             commandBuilder.append(" ");
             commandBuilder.append(addon.getSettings().getPlayerCommand().split(" ")[0]);
 
-            if (!available) {
-                component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + "click-text-to-purchase",
-                        Constants.PARAMETER_BIOME, biome.getFriendlyName()));
-            } else
-            {
-                component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + "click-text-to-set",
-                        Constants.PARAMETER_BIOME, biome.getFriendlyName()));
-            }
-
+            String key = available ? "click-text-to-set" : "click-text-to-purchase";
+            TextComponent component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + key,
+                    Constants.PARAMETER_BIOME, biome.getFriendlyName()));
             component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandBuilder.toString()));
 
             user.getPlayer().spigot().sendMessage(component);
+        }
+        else
+        {
+            String gameModeName = BentoBox.getInstance().getIWM().getAddon(island.getWorld())
+                    .map(a -> a.getDescription().getName()).orElse("");
+            String key = available ? "click-text-to-set-other-world" : "click-text-to-purchase-other-world";
+            user.sendMessage(Constants.CONVERSATIONS + key,
+                    Constants.PARAMETER_BIOME, biome.getFriendlyName(),
+                    "[gamemode]", gameModeName);
         }
     }
 

--- a/src/main/java/world/bentobox/biomes/utils/Utils.java
+++ b/src/main/java/world/bentobox/biomes/utils/Utils.java
@@ -511,32 +511,25 @@ public class Utils
         World playerWorld = user.getWorld();
         String playerGameMode = playerWorld == null ? "" : getGameMode(playerWorld);
 
-        if (!islandGameMode.isEmpty() && islandGameMode.equals(playerGameMode))
+        if (islandGameMode.isEmpty() || !islandGameMode.equals(playerGameMode))
         {
-            WorldSettings settings = addon.getPlugin().getIWM().getWorldSettings(island.getWorld());
-
-            StringBuilder commandBuilder = new StringBuilder();
-            commandBuilder.append("/");
-            commandBuilder.append(settings.getPlayerCommandAliases().split(" ")[0]);
-            commandBuilder.append(" ");
-            commandBuilder.append(addon.getSettings().getPlayerCommand().split(" ")[0]);
-
-            String key = available ? "click-text-to-set" : "click-text-to-purchase";
-            TextComponent component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + key,
-                    Constants.PARAMETER_BIOME, biome.getFriendlyName()));
-            component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandBuilder.toString()));
-
-            user.getPlayer().spigot().sendMessage(component);
+            return;
         }
-        else
-        {
-            String gameModeName = BentoBox.getInstance().getIWM().getAddon(island.getWorld())
-                    .map(a -> a.getDescription().getName()).orElse("");
-            String key = available ? "click-text-to-set-other-world" : "click-text-to-purchase-other-world";
-            user.sendMessage(Constants.CONVERSATIONS + key,
-                    Constants.PARAMETER_BIOME, biome.getFriendlyName(),
-                    "[gamemode]", gameModeName);
-        }
+
+        WorldSettings settings = addon.getPlugin().getIWM().getWorldSettings(island.getWorld());
+
+        StringBuilder commandBuilder = new StringBuilder();
+        commandBuilder.append("/");
+        commandBuilder.append(settings.getPlayerCommandAliases().split(" ")[0]);
+        commandBuilder.append(" ");
+        commandBuilder.append(addon.getSettings().getPlayerCommand().split(" ")[0]);
+
+        String key = available ? "click-text-to-set" : "click-text-to-purchase";
+        TextComponent component = new TextComponent(user.getTranslation(Constants.CONVERSATIONS + key,
+                Constants.PARAMETER_BIOME, biome.getFriendlyName()));
+        component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandBuilder.toString()));
+
+        user.getPlayer().spigot().sendMessage(component);
     }
 
 

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -828,10 +828,6 @@ biomes:
     click-text-to-purchase: "&e You have unlocked &r [biome]&r&e! Click here to buy it."
     # Message that appears when user unlocks new biome and can already use it.
     click-text-to-set: "&e You have unlocked &r [biome]&r&e! Click here to use it."
-    # Message shown when a biome is unlocked while the player is outside that gamemode world.
-    click-text-to-purchase-other-world: "&e You have unlocked &r [biome]&r&e in &r [gamemode]&r&e! Visit that world to buy it."
-    # Message shown when a biome is unlocked while the player is outside that gamemode world.
-    click-text-to-set-other-world: "&e You have unlocked &r [biome]&r&e in &r [gamemode]&r&e! Visit that world to use it."
   messages:
     # Message that is sent to a player if he tries to use locked biome.
     biome-not-unlocked: "[biome] &r&c is not unlocked. You cannot use it."

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -828,6 +828,10 @@ biomes:
     click-text-to-purchase: "&e You have unlocked &r [biome]&r&e! Click here to buy it."
     # Message that appears when user unlocks new biome and can already use it.
     click-text-to-set: "&e You have unlocked &r [biome]&r&e! Click here to use it."
+    # Message shown when a biome is unlocked while the player is outside that gamemode world.
+    click-text-to-purchase-other-world: "&e You have unlocked &r [biome]&r&e in &r [gamemode]&r&e! Visit that world to buy it."
+    # Message shown when a biome is unlocked while the player is outside that gamemode world.
+    click-text-to-set-other-world: "&e You have unlocked &r [biome]&r&e in &r [gamemode]&r&e! Visit that world to use it."
   messages:
     # Message that is sent to a player if he tries to use locked biome.
     biome-not-unlocked: "[biome] &r&c is not unlocked. You cannot use it."


### PR DESCRIPTION
## Summary
- When a biome unlocks, only send the clickable "use it now" prompt if the player is currently in that island's gamemode world.
- Players in other worlds (e.g. `/wilderness`, a different gamemode) receive a plain message naming the gamemode instead, so they know where the unlock applies and aren't misled into running a command in the wrong world.
- Adds two new locale keys (`click-text-to-purchase-other-world`, `click-text-to-set-other-world`) in `en-US.yml`.

Closes #112

## Test plan
- [x] Multi-gamemode dev server (e.g. BSkyBlock + AcidIsland + a non-addon world).
- [x] Trigger an unlock while standing on the correct island → clickable message as before; click runs the gamemode command.
- [x] Trigger an unlock while the recipient is in a different gamemode or `/wilderness` → non-clickable message naming the gamemode.
- [x] Rejoin the server outside the gamemode world → JoinLeaveListener path produces the gamemode-named variant.
- [x] Offline members still receive nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)