### PR TITLE
Modernisation cleanup: pom.xml, plugin.yml api-version, IslandLevelListener test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <powermock.version>2.0.2</powermock.version>
         <!-- Test dependency versions -->
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.11.0</mockito.version>
         <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
-        <spigot.version>1.21.11-R0.1-SNAPSHOT</spigot.version>
         <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
         <bentobox.version>3.14.0</bentobox.version>
         <bank.version>1.4.0</bank.version>
@@ -114,16 +112,20 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>codemc-repo</id>
+            <id>bentoboxworld</id>
             <url>https://repo.codemc.org/repository/bentoboxworld/</url>
         </repository>
         <repository>
-            <id>papermc</id>
-            <url>https://repo.papermc.io/repository/maven-public/</url>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>codemc</id>
+            <url>https://repo.codemc.org/repository/maven-snapshots/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
@@ -252,11 +254,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <release>${java.version}</release>
+                    <fork>true</fork>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: BentoBox-Biomes
 main: world.bentobox.biomes.BiomesPladdon
 version: ${project.version}${build.number}
-api-version: "1.19"
+api-version: "1.21"
 
 authors: [BONNe]
 contributors: ["The BentoBoxWorld Community"]

--- a/src/test/java/world/bentobox/biomes/listeners/IslandLevelListenerTest.java
+++ b/src/test/java/world/bentobox/biomes/listeners/IslandLevelListenerTest.java
@@ -1,0 +1,53 @@
+package world.bentobox.biomes.listeners;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.biomes.BiomesAddon;
+import world.bentobox.biomes.CommonTestSetup;
+import world.bentobox.biomes.managers.BiomesAddonManager;
+import world.bentobox.level.events.IslandLevelCalculatedEvent;
+
+/**
+ * Tests for {@link IslandLevelListener}.
+ */
+class IslandLevelListenerTest extends CommonTestSetup {
+
+    @Mock
+    private BiomesAddon addon;
+    @Mock
+    private BiomesAddonManager addonManager;
+    @Mock
+    private Island testIsland;
+
+    private IslandLevelListener listener;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        when(addon.getAddonManager()).thenReturn(addonManager);
+        listener = new IslandLevelListener(addon);
+    }
+
+    @Test
+    void testOnLevelCalculated() {
+        IslandLevelCalculatedEvent event = mock(IslandLevelCalculatedEvent.class);
+        when(event.getIsland()).thenReturn(testIsland);
+        when(event.getTargetPlayer()).thenReturn(uuid);
+        when(event.getLevel()).thenReturn(42L);
+
+        listener.onLevelCalculated(event);
+
+        verify(addonManager).checkBiomesUnlockStatus(eq(testIsland), any(User.class), eq(42L));
+    }
+}


### PR DESCRIPTION
## Summary
- `plugin.yml`: bump `api-version` from `1.19` to `1.21` to match the Paper 1.21.11 runtime already declared in `pom.xml`.
- `pom.xml`: drop unused `powermock.version` / `spigot.version` properties and the Spigot Nexus repository; add the codemc maven-public + snapshots repos alongside the existing bentoboxworld repo; bump `maven-compiler-plugin` 3.7.0 → 3.15.0 with `fork=true` for Java 21 toolchain compatibility.
- Add `IslandLevelListenerTest` so every event listener in the addon now has a test.

## Test plan
- [x] `mvn test` — 82 tests, 0 failures (81 existing + 1 new)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)