### PR TITLE
Add MC 26.1.2 to Modrinth game-versions

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -94,6 +94,7 @@ jobs:
             1.21.11
             26.1
             26.1.1
+            26.1.2
 
           # Path to the built JAR — Maven produces Biomes-{version}.jar in target/
           files: target/Biomes-${{ github.event.release.tag_name || inputs.tag }}.jar


### PR DESCRIPTION
Adds Minecraft `26.1.2` to the `game-versions` list in the new Modrinth publish workflow.

This targets the `ci/modrinth-publish` branch (PR #168), where the workflow currently lives, so it ships with 26.1.2 already included rather than needing a follow-up once #168 merges. Matches the 26.1.2 update applied across the other addons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)