### PR TITLE
fix: default change-ocean-biomes to true (fixes #171)

### DIFF
--- a/src/main/java/world/bentobox/biomes/config/Settings.java
+++ b/src/main/java/world/bentobox/biomes/config/Settings.java
@@ -509,10 +509,12 @@ public class Settings implements ConfigObject
     @ConfigComment("in an ocean biome (OCEAN, WARM_OCEAN, LUKEWARM_OCEAN, COLD_OCEAN, FROZEN_OCEAN,")
     @ConfigComment("DEEP_OCEAN, DEEP_LUKEWARM_OCEAN, DEEP_COLD_OCEAN, DEEP_FROZEN_OCEAN).")
     @ConfigComment("If set to false, those blocks will keep their ocean biome and will not be changed.")
-    @ConfigComment("Default value = false")
+    @ConfigComment("Note: islands in void worlds (e.g. SkyBlock) default to an ocean biome, so")
+    @ConfigComment("setting this to false will prevent biome changes from taking effect on them.")
+    @ConfigComment("Default value = true")
     @ConfigEntry(path = "change-ocean-biomes")
     @SuppressWarnings("javadoc")
-    private boolean changeOceanBiomes = false;
+    private boolean changeOceanBiomes = true;
 
     @ConfigComment("")
     @ConfigComment("For advanced menu this indicate how large range will be set on GUI opening.")


### PR DESCRIPTION
## Problem

Reported in #171: biome changes appear to do nothing on default islands. The task reports success and logs `changed biome in loaded chunks to <biome>`, but the biome stays `warm_ocean` even after restart/relog. No console errors.

## Root cause

Not a Minecraft 26.1.2 issue. The `change-ocean-biomes` config option (added in #159) defaults to **`false`**, which makes `BiomeUpdateTask.runBiomeChange()` skip every block whose **current** biome is an ocean biome:

```java
if (!changeOceanBiomes && OCEAN_BIOMES.contains(this.world.getBiome(x, y, z))) {
    continue;
}
```

Islands in void worlds (SkyBlock, AcidIsland, etc.) default to an ocean biome — typically `warm_ocean`. So on a fresh island **every block is an ocean biome**, every block gets skipped, and nothing changes. The task still walks all chunks, completes as `FINISHED`, and logs the success message — which is why it looked broken with no errors.

## Fix

Flip the default to `true`, restoring pre-#159 behavior for everyone by default. Admins who want to preserve the surrounding sea can still opt out by setting `change-ocean-biomes: false`. Also added a config comment warning about the void-world caveat.

> [!NOTE]
> Servers with an already-generated `config.yml` keep their saved `change-ocean-biomes: false` and must set it to `true` (or delete the line) for the fix to apply.

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)