### PR TITLE
fix: add missing change-ocean-biomes entry to config.yml template

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,15 @@
 #     'RANGE' - updates biome by block in given range
 default-mode: ISLAND
 #
+# This indicates if biome changes should also affect blocks that are currently
+# in an ocean biome (OCEAN, WARM_OCEAN, LUKEWARM_OCEAN, COLD_OCEAN, FROZEN_OCEAN,
+# DEEP_OCEAN, DEEP_LUKEWARM_OCEAN, DEEP_COLD_OCEAN, DEEP_FROZEN_OCEAN).
+# If set to false, those blocks will keep their ocean biome and will not be changed.
+# Note: islands in void worlds (e.g. SkyBlock) default to an ocean biome, so
+# setting this to false will prevent biome changes from taking effect on them.
+# Default value = true
+change-ocean-biomes: true
+#
 # For advanced menu this indicate how large range will be set on GUI opening.
 # If advanced menu is disabled or in biome set command update range is not set
 # then update algorithm will use this value as update range.


### PR DESCRIPTION
## Problem

Follow-up to #172 / #171. After flipping the `change-ocean-biomes` default to `true`, testing showed the option still does not appear in the generated `config.yml` — even after deleting the file and restarting.

## Root cause

This addon ships a **hand-maintained** `src/main/resources/config.yml`. `saveDefaultConfig()` copies it to disk as the on-disk template, and BentoBox does **not** regenerate it from the `@ConfigEntry` annotations while that resource file exists. PR #159 added `change-ocean-biomes` to `Settings.java` but never added it to the template — it is the **only** setting in `Settings.java` missing from `config.yml`. As a result the option was invisible and unconfigurable; admins could not turn it on even if they wanted to.

When the key is absent, BentoBox falls back to the field default, so the #172 behaviour fix does take effect — but the option needs to be present in the template to be visible and editable.

## Fix

Add the `change-ocean-biomes: true` entry (with comments matching the `@ConfigComment` text) to the resource `config.yml`, in the same order as `Settings.java`.

> [!NOTE]
> Existing servers keep their on-disk `config.yml`; this only affects freshly generated configs. Servers upgrading from 2.3.0 still won't have the key written and should add `change-ocean-biomes: true` manually (or delete config.yml to regenerate).

Follow-up to #172, fixes the remaining part of #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)