### PR TITLE
fix: self-heal config.yml on load (write back missing keys)

### DIFF
--- a/src/main/java/world/bentobox/biomes/BiomesAddon.java
+++ b/src/main/java/world/bentobox/biomes/BiomesAddon.java
@@ -287,7 +287,13 @@ public class BiomesAddon extends Addon
             // Disable
             this.logError("Biomes settings could not load! Addon disabled.");
             this.setState(State.DISABLED);
+            return;
         }
+
+        // Save the settings straight back to disk. Loading only reads values and never writes
+        // missing keys, so this ensures any config options that were added to the Settings class
+        // but are absent from an existing config.yml are written out with their default values.
+        this.saveSettings();
 
         // Save existing panels.
         this.saveResource("panels/main_panel.yml", false);


### PR DESCRIPTION
## Problem

Root cause behind #171, found while testing #172/#174: new config options added to `Settings.java` never appear in an existing server's `config.yml`. The reporter could not see or change `change-ocean-biomes` even after deleting and regenerating the file.

## Why

`Config.loadConfigObject()` → `createObject()` only **reads**: it builds a `Settings` instance (fields at their in-code defaults), then for each field overwrites it **only if** `config.contains(path)`. It never writes anything back. Nothing in `BiomesAddon.loadSettings()` calls `saveConfigObject()` afterwards, so the on-disk `config.yml` is never regenerated and missing keys are never added. (The "missing keys get added automatically" behaviour people remember is the **locale** system, not `Config`.)

## Fix

Call `saveSettings()` immediately after a successful load in `loadSettings()`. `saveObject()` serializes **all** `@ConfigEntry` fields (with their `@ConfigComment`s), so the file is rewritten with any newly added options at their defaults, while existing values are preserved. This makes the config self-heal on every load — the behaviour that was expected all along.

Also added the missing early `return` when settings fail to load, so the panel/template `saveResource` calls don't run against a null `settings`.

> [!NOTE]
> This rewrites `config.yml` on load, which reorders keys to match `Settings.java` and regenerates comments. That's the intended self-healing behaviour.

Tests: `BiomesAddonTest` passes (13/13).

Follow-up to #172 / #174. Relates to #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)