### PR TITLE
Release 2.3.1

### DIFF
--- a/src/main/java/world/bentobox/biomes/BiomesAddon.java
+++ b/src/main/java/world/bentobox/biomes/BiomesAddon.java
@@ -287,7 +287,13 @@ public class BiomesAddon extends Addon
             // Disable
             this.logError("Biomes settings could not load! Addon disabled.");
             this.setState(State.DISABLED);
+            return;
         }
+
+        // Save the settings straight back to disk. Loading only reads values and never writes
+        // missing keys, so this ensures any config options that were added to the Settings class
+        // but are absent from an existing config.yml are written out with their default values.
+        this.saveSettings();
 
         // Save existing panels.
         this.saveResource("panels/main_panel.yml", false);


### PR DESCRIPTION
Release PR for **2.3.1** — brings the remaining ocean-biome / config self-heal fix from `develop` into `master`.

## What's in this release

* ⚙️🔺 **`change-ocean-biomes` default flipped to `true`** (#172) — restores biome changing on ocean-biome islands (SkyBlock/AcidIsland void worlds). Fixes #171.
* ⚙️ **Added `change-ocean-biomes` to the config.yml template** (#174) — the option was missing from the shipped config and was therefore invisible/unconfigurable.
* 🔧 **config.yml now self-heals on load** (#175) — `loadSettings()` writes settings back after loading, so newly added options are written to existing configs with their defaults. This is the root-cause fix: previously loading never added missing keys, which is why the option never appeared.

> 🔺 Servers upgrading from 2.3.0: with #175 the config self-heals, so `change-ocean-biomes: true` is written automatically on first load — no manual edit needed. Biome changes work again out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)