### PR TITLE
Version 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>2.3.1</build.version>
+        <build.version>2.3.2</build.version>
         <build.number>-LOCAL</build.number>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Biomes</sonar.projectKey>


### PR DESCRIPTION
Bump `build.version` to 2.3.2 for the patch release containing #174 (config.yml template entry) and #175 (config self-heal on load), which landed after 2.3.1 had already been published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)