### PR TITLE
Release 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>2.3.1</build.version>
+        <build.version>2.3.2</build.version>
         <build.number>-LOCAL</build.number>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Biomes</sonar.projectKey>


### PR DESCRIPTION
Release **2.3.2** — patch release for the config-handling fixes that landed after 2.3.1 was published.

## What's in this release

* ⚙️ **`change-ocean-biomes` added to the config.yml template** (#174) — the option was missing from the shipped config, so it never appeared on disk and couldn't be configured.
* 🔧 **`config.yml` now self-heals on load** (#175) — `loadSettings()` writes settings back after loading, so newly added options are written to existing configs automatically with their defaults. Previously loading never wrote missing keys, which is why `change-ocean-biomes` never showed up. This is the root-cause fix.

Together these complete the fix for [#171](https://github.com/BentoBoxWorld/Biomes/issues/171): on a server upgrading from 2.3.0/2.3.1, the config now self-heals and `change-ocean-biomes: true` is written automatically — biome changes work out of the box with no manual edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)